### PR TITLE
Navigations smol changes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
   <script src="./assets/anim.js"></script>
 
   <!-- -----------------------NAVBAR--------------------- -->
-
+  
   <nav class="navbar navbar-expand-lg navbar-dark p-lg-5" id="navbar">
     <a class="navbar-brand px-md-4" href="#">Ideathon</a>
     <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup"
@@ -111,22 +111,26 @@
   </div>
 
   <!-- -------------PROBLEM STATEMENTS----------- -->
-  <div class="container problem-content my-5 pb-xl-5" data-aos="fade-up" id="problem" data-aos-duration="800">
-    <h1 class="text-center mb-lg-4">PROBLEM STATEMENTS</h1>
-    <h5> You can select problem from the following :</h5o>
-      <h6> Monitoring social distancing in COVID-19.</h6>
-      <h6> Pattern classification of COVID-19 growth data.</h6>
-      <h6> Tracking COVID-19 symptoms.</h6>
-      <h6> System to track COVID-19 hospitals and no. of beds available.</h6>
-      <h6> Improvising teaching and learning concepts to educate children at the
-        village side in this pandemic COVID-19 situation.</h6>
-      <h6> Contact tracing in COVID-19.</h6>
-      <h6> Tracking growth rate of COVID-19.</h6>
-      <h6> Masked Face Recognition and Touch less Biometrics at the time of COVID-19.</h6>
-      <h6> COVID-19 detection using Chest X-Ray.</h6>
-      <h6> COVID-19 detection using Speech.</h6>
-      <!-- <p class="text-center py-3" style="color: #ff8080;">Solution to the problem should be innovative and should have -->
-      <!-- social impact !</p> -->
+  <span class="anchor"></span>
+  <div id="problem">
+    <div class="container problem-content my-5 pb-xl-5" data-aos="fade-up" data-aos-duration="800">
+      
+      <h1 class="text-center mb-lg-4">PROBLEM STATEMENTS</h1>
+      <h5> You can select problem from the following :</h5o>
+        <h6> Monitoring social distancing in COVID-19.</h6>
+        <h6> Pattern classification of COVID-19 growth data.</h6>
+        <h6> Tracking COVID-19 symptoms.</h6>
+        <h6> System to track COVID-19 hospitals and no. of beds available.</h6>
+        <h6> Improvising teaching and learning concepts to educate children at the
+          village side in this pandemic COVID-19 situation.</h6>
+        <h6> Contact tracing in COVID-19.</h6>
+        <h6> Tracking growth rate of COVID-19.</h6>
+        <h6> Masked Face Recognition and Touch less Biometrics at the time of COVID-19.</h6>
+        <h6> COVID-19 detection using Chest X-Ray.</h6>
+        <h6> COVID-19 detection using Speech.</h6>
+        <!-- <p class="text-center py-3" style="color: #ff8080;">Solution to the problem should be innovative and should have -->
+        <!-- social impact !</p> -->
+    </div>
   </div>
 
   <!-- ------------PRIZES----------- -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -12,6 +12,12 @@ html{
   overflow-x: hidden;
 }
 
+.anchor {
+  display: block;
+  height:136px;
+  margin-top:-136px;
+  visibility: hidden;
+}
 /* ----------NAVBAR----------- */
 .nav-link {
   padding: 0 1rem !important;


### PR DESCRIPTION
Navigating to problem statements section through navbar used to hide the title and first line of the section. 
ALSO COOL SITE YO :).
Before after images respectively:
![IdeathonBefore](https://user-images.githubusercontent.com/55539563/95212417-4e860300-080b-11eb-8f44-874538f6c4e4.png)
![IdeathonAfter](https://user-images.githubusercontent.com/55539563/95212439-534ab700-080b-11eb-9ed6-f0692526a995.png)

